### PR TITLE
 Fix: resolve FUNCTION_INVOCATION_FAILED on Vercel

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,10 +35,8 @@ app.use(
     credentials: true, // Important for better-auth cookies
     methods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
     allowedHeaders: ["Content-Type", "Authorization"],
-  })
+  }),
 );
-
-app.use(bodyParser.json());
 
 // Apply rate limiting to all routes
 app.use(apiLimiter);
@@ -62,7 +60,11 @@ app.get("/", (req, res) => {
 docs(app);
 
 // Your API routes (includes better-auth routes)
+// Better-Auth needs the raw request body, so mount before bodyParser.json()
 app.use("/api", router);
+
+// Body parser for non-auth routes (must come after the better-auth handler)
+app.use(bodyParser.json());
 
 // 404 handler - must be after all routes
 app.use((req, res, _next) => {
@@ -78,7 +80,7 @@ app.use(
     err: any,
     _req: express.Request,
     res: express.Response,
-    _next: express.NextFunction
+    _next: express.NextFunction,
   ) => {
     console.error("❌ Unhandled error:", err);
 
@@ -90,7 +92,7 @@ app.use(
     const errorData = IS_PRODUCTION ? null : { stack: err.stack, details: err };
 
     ResponseUtil.error(res, err.statusCode || 500, errorMessage, errorData);
-  }
+  },
 );
 
 // For local development

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -9,7 +9,7 @@ const envSchema = z.object({
     .min(1, "DATABASE_URL is required")
     .refine(
       (url) => url.startsWith("mongodb://") || url.startsWith("mongodb+srv://"),
-      "DATABASE_URL must be a valid MongoDB connection string"
+      "DATABASE_URL must be a valid MongoDB connection string",
     ),
   SECRET: z
     .string()
@@ -74,16 +74,13 @@ function validateEnv() {
     return parsed;
   } catch (error) {
     if (error instanceof z.ZodError) {
-      console.error("❌ Invalid environment variables:");
-      error.issues.forEach((err: z.ZodIssue) => {
-        console.error(`  - ${err.path.join(".")}: ${err.message}`);
-      });
-      console.error(
-        "\n💡 Please check your .env file and ensure all required variables are set."
-      );
-      console.error("📄 Refer to .env.example for the required format.\n");
+      const details = error.issues
+        .map((err: z.ZodIssue) => `  - ${err.path.join(".")}: ${err.message}`)
+        .join("\n");
+      console.error("❌ Invalid environment variables:\n" + details);
+      throw new Error("Invalid environment variables:\n" + details);
     }
-    process.exit(1);
+    throw error;
   }
 }
 


### PR DESCRIPTION
### Problem
The serverless function crashed on Vercel with `FUNCTION_INVOCATION_FAILED`.

### Root cause
1. `src/utils/env.ts` called `process.exit(1)` when env validation failed.
   On Vercel this kills the worker during cold start with no useful log,
   surfacing as an opaque `FUNCTION_INVOCATION_FAILED`.
2. `bodyParser.json()` ran globally before the Better-Auth handler, consuming
   the raw request body that `toNodeHandler(auth)` needs.

### Changes
- `env.ts`: throw a descriptive error (listing the offending variables)
  instead of `process.exit(1)`, so Vercel logs show exactly what is missing.
- `index.ts`: mount the `/api` (Better-Auth) routes before `bodyParser.json()`.